### PR TITLE
Fixed placeholder image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={"placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
![Bug fix](https://user-images.githubusercontent.com/93187830/195255772-eed851bb-5646-4ec3-93b6-4572f2defacb.png)

Items without a provided image will now display a placeholder image, instead of having blank space.



